### PR TITLE
feature(parameter-pattern): improve unicode support

### DIFF
--- a/.github/workflows/lint-test-workflow.yml
+++ b/.github/workflows/lint-test-workflow.yml
@@ -59,10 +59,19 @@ jobs:
         shell: bash
         env:
           CI: true
-      - name: test
+      - name: test + coverage
         run: |
           node --version
           npm run test:cover
+        if: matrix.platform == 'ubuntu-latest' && matrix.node-version != '8.x'
+        shell: bash
+        env:
+          CI: true
+      - name: test only (node 8)
+        run: |
+          node --version
+          npm run test
+        if: matrix.platform == 'ubuntu-latest' && matrix.node-version == '8.x'
         shell: bash
         env:
           CI: true

--- a/docs/rules/parameter-pattern.md
+++ b/docs/rules/parameter-pattern.md
@@ -3,7 +3,7 @@
 This rule enforces that parameter names start with a `p` and are pascal cased. There's an exception for
 starting with the `_` character as that (by convention) is often used for unused parameters.
 
-🔧 The `--fix option` on the command line renames parameters to the correct pattern (including 
+🔧 The `--fix option` on the command line renames parameters to the correct pattern (including
 any use in the function body).
 
 ## Rule Details
@@ -20,6 +20,10 @@ const f = thing => {
 };
 
 const f = piedPiper => {
+  /* do stuff */
+};
+
+const f = параметр => {
   /* do stuff */
 };
 ```
@@ -39,8 +43,12 @@ const f = pPiedPiper => {
   /* do stuff */
 };
 
+const f = pПараметр => {
+  /* do stuff */
+};
+
 function f(_, pThing) {
-    // to stuff with pThing, but not with _
+  // to stuff with pThing, but not with _
 }
 ```
 
@@ -53,8 +61,10 @@ If there are any options, describe them here. Otherwise, delete this section.
 ## When Not To Use It
 
 - If you don't want to have this parameter naming convention.
-- When you use parameter names that contain non-ascii characters (e.g. _paramètre_, _параметр_ or _参数_ will be
-  flagged and cannot be auto corrected a.t.m.)
+- When you use parameter names that contain non-ascii characters from alphabets that
+  don't have upper and lower case.     
+  E.g. _参数_ will be flagged and cannot be auto corrected  a.t.m., but _параметр_ and
+  _paramètre_ _can_ be autocorrected. Likewise _pПараметр_ and _pParamètre_ are valid.
 
 <!--
 ## Further Reading

--- a/lib/rules/parameter-pattern-utl.js
+++ b/lib/rules/parameter-pattern-utl.js
@@ -1,0 +1,22 @@
+const nodeVersionIsRecentEnough = require("../utl/node-version-is-recent-enough");
+
+function getValidParameterPattern(pMajorNodeVersion) {
+    // unicode pattern matching is only available from node 10
+    return nodeVersionIsRecentEnough(pMajorNodeVersion)
+        ? /^(p[\p{Lu}]|_)\S*/u
+        : /^(p[A-Z]|_)\S*/;
+}
+
+function getParameterReplacementPattern(lParameterName, pMajorNodeVersion) {
+    return nodeVersionIsRecentEnough(pMajorNodeVersion)
+        ? new RegExp(
+            `([^\\p{L}\\p{N}]|^)${lParameterName}([^\\p{L}\\p{N}]|$)`,
+            "gu"
+        )
+        : new RegExp(`(\\W|^)${lParameterName}(\\W|$)`, "g");
+}
+
+module.exports = {
+    getValidParameterPattern,
+    getParameterReplacementPattern
+}

--- a/lib/rules/parameter-pattern.js
+++ b/lib/rules/parameter-pattern.js
@@ -1,4 +1,8 @@
 const _get = require("lodash.get");
+const {
+  getValidParameterPattern,
+  getParameterReplacementPattern
+} = require("./parameter-pattern-utl");
 /**
  * @fileoverview Enforce function parameters to adhere to a pattern
  * @author sverweij
@@ -18,15 +22,10 @@ module.exports = {
       url:
         "https://sverweij.github.io/eslint-plugin-budapestian/rules/parameter-pattern"
     },
-    fixable: "code", // or "code" or "whitespace"
-    schema: [
-      // fill in your schema
-    ]
+    fixable: "code",
   },
 
   create: pContext => {
-    const PARAMETER_PATTERN = /^(p[A-Z]|_)\S*/;
-
     //----------------------------------------------------------------------
     // Helpers
     //----------------------------------------------------------------------
@@ -41,10 +40,14 @@ module.exports = {
         .concat(pString.slice(1))}`;
     }
 
+    function parameterNameIsValid(pString) {
+      return pString.match(getValidParameterPattern());
+    }
+
     function checkParameters(pNode, pContext) {
       _get(pNode, "params", []).forEach(pParam => {
         const lParameterName = getParameterName(pParam);
-        if (!lParameterName.match(PARAMETER_PATTERN)) {
+        if (!parameterNameIsValid(lParameterName)) {
           pContext.report({
             node: pNode,
             message: `parameter '{{ identifier }}' should be pascal case and start with a p: '{{ betterIdentifier }}'`,
@@ -57,10 +60,7 @@ module.exports = {
                 .getSourceCode()
                 .getText(pNode)
                 .replace(
-                  // TODO: doesn't work really well with non-ascii
-                  //       maybe use the power of the AST(tm) here as well
-                  //       instead of re-hacking
-                  new RegExp(`(\\W|^)${lParameterName}(\\W|$)`, "g"),
+                  getParameterReplacementPattern(lParameterName),
                   `$1${normalizeParameterName(lParameterName)}$2`
                 );
               return pFixer.replaceText(pNode, lBetterized);

--- a/lib/utl/node-version-is-recent-enough.js
+++ b/lib/utl/node-version-is-recent-enough.js
@@ -1,0 +1,7 @@
+function getMajorNodeVersion() {
+  return process.versions.node.split(".").shift();
+}
+
+module.exports = function nodeVersionIsRecentEnough(pMajorNodeVersion = getMajorNodeVersion()) {
+  return Number.parseInt(pMajorNodeVersion) >= 10;
+};

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
       "*.js",
       "coverage/**/*",
       "tmp*",
-      "docs/**/*"
+      "docs/**/*",
+      "test/**/*"
     ],
     "reporter": [
       "text-summary",

--- a/test/lib/rules/parameter-pattern-utl.spec.js
+++ b/test/lib/rules/parameter-pattern-utl.spec.js
@@ -1,0 +1,30 @@
+const {
+  getValidParameterPattern,
+  getParameterReplacementPattern
+} = require("../../../lib/rules/parameter-pattern-utl");
+const nodeVersionIsRecentEngough = require("../../../lib/utl/node-version-is-recent-enough");
+
+if (nodeVersionIsRecentEngough()) {
+  const expect = require("chai").expect;
+
+  describe("parameter-pattern-utl - getValidParameterPattern", () => {
+    it("on node 8 (and below) should have no flags", () => {
+      expect(getValidParameterPattern(8).flags).to.equal("");
+    });
+    it("on node 10 (and up) should have the unicode flag", () => {
+      expect(getValidParameterPattern(10).flags).to.equal("u");
+    });
+  });
+  describe("parameter-pattern-utl - getParameterReplacementPattern", () => {
+    it("on node 8 (and below) should have no flags", () => {
+      expect(getParameterReplacementPattern("something", 8).flags).to.equal(
+        "g"
+      );
+    });
+    it("on node 10 (and up) should have the unicode flag", () => {
+      expect(getParameterReplacementPattern("something", 10).flags).to.equal(
+        "gu"
+      );
+    });
+  });
+}

--- a/test/lib/rules/parameter-pattern.spec.js
+++ b/test/lib/rules/parameter-pattern.spec.js
@@ -1,4 +1,5 @@
 const rule = require("../../../lib/rules/parameter-pattern");
+const nodeVersionIsRecentEnough = require("../../../lib/utl/node-version-is-recent-enough");
 const RuleTester = require("eslint").RuleTester;
 
 const ruleTester = new RuleTester({
@@ -19,7 +20,6 @@ ruleTester.run("enforce-parameter-pattern", rule, {
     "const f = (pThing = 1234) => { }",
     "const f = () => { }",
     "const f = (_Параметр) => { }"
-    // "const f = (pПараметр) => { }"
   ],
 
   invalid: [
@@ -119,3 +119,61 @@ ruleTester.run("enforce-parameter-pattern", rule, {
     }
   ]
 });
+
+// unicode matching works properly from node >=10
+if (nodeVersionIsRecentEnough()) {
+  ruleTester.run("enforce-parameter-pattern unicode (node >= 10)", rule, {
+    valid: [
+      "function функция (pПараметр) { }",
+      "const ф = (pПараметр) => { }"
+      // "const ф = (p参数) => { }"
+    ],
+
+    invalid: [
+      {
+        code: "function doSomething(параметр) { const lLala = параметр }",
+        errors: [
+          {
+            message: `parameter 'параметр' should be pascal case and start with a p: 'pПараметр'`,
+            type: "FunctionDeclaration"
+          }
+        ],
+        output: "function doSomething(pПараметр) { const lLala = pПараметр }"
+      },
+      {
+        code: "const f = (функцияПараметр) => { }",
+        errors: [
+          {
+            message: `parameter 'функцияПараметр' should be pascal case and start with a p: 'pФункцияПараметр'`,
+            type: "ArrowFunctionExpression"
+          }
+        ],
+        output: "const f = (pФункцияПараметр) => { }"
+      },
+      // only replace within own scope
+      {
+        code:
+          "function otherFunction() {let парам = 123} function doSomething(парам) { const lSomeConst = парам }",
+        errors: [
+          {
+            message: `parameter 'парам' should be pascal case and start with a p: 'pПарам'`,
+            type: "FunctionDeclaration"
+          }
+        ],
+        output:
+          "function otherFunction() {let парам = 123} function doSomething(pПарам) { const lSomeConst = pПарам }"
+      },
+      // replace whole word only
+      {
+        code: "function doSomething(парам) { const параметр=парам }",
+        errors: [
+          {
+            message: `parameter 'парам' should be pascal case and start with a p: 'pПарам'`,
+            type: "FunctionDeclaration"
+          }
+        ],
+        output: "function doSomething(pПарам) { const параметр=pПарам }"
+      }
+    ]
+  });
+}


### PR DESCRIPTION
## Description, Motivation and Context

- Improves the detection and auto fix logic of the parameter-pattern rule so it works with a slightly wider range of languages (at least those that have upper and lower case). 
- Uses a node 10+ feature (unicode regular expressions stuff), so this _feature_ only works on those platforms - on lower versions of node it falls back to the previous ASCII only behaviour.

## How Has This Been Tested?

- additional unit tests
- green ci


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
