### PR TITLE
bugfix(parameter-pattern): outfox: replace all parameters in a function a.o.t. only the first one

### DIFF
--- a/lib/rules/parameter-pattern.js
+++ b/lib/rules/parameter-pattern.js
@@ -27,6 +27,23 @@ function parameterNameIsValid(pString) {
 // Rule Definition
 //------------------------------------------------------------------------------
 
+function getFixes(pContext, pNode, pProblematicParameterNames, pFire=true) {
+  if (pFire) {
+    return pFixer => {
+      let lBetterized = pProblematicParameterNames.reduce(
+          (pSource, pProblematicParameterName) =>
+              pSource.replace(
+                  getIdentifierReplacementPattern(pProblematicParameterName),
+                  `$1${normalizeParameterName(pProblematicParameterName)}$2`
+              ),
+          pContext.getSourceCode().getText(pNode)
+      );
+
+      return pFixer.replaceText(pNode, lBetterized);
+    };
+  }
+}
+
 module.exports = {
   meta: {
     type: "suggestion",
@@ -42,31 +59,22 @@ module.exports = {
 
   create: pContext => {
     function checkParameters(pNode, pContext) {
-      _get(pNode, "params", []).forEach(pParameter => {
-        const lParameterName = getParameterName(pParameter);
+      const lProblematicParameterNames = _get(pNode, "params", [])
+        .map(getParameterName)
+        .filter(pParameterName => !parameterNameIsValid(pParameterName));
 
-        if (!parameterNameIsValid(lParameterName)) {
-          pContext.report({
-            node: pNode,
-            message: `parameter '{{ identifier }}' should be pascal case and start with a p: '{{ betterIdentifier }}'`,
-            data: {
-              identifier: lParameterName,
-              betterIdentifier: normalizeParameterName(lParameterName)
-            },
-            fix: pFixer => {
-              const lBetterized = pContext
-                .getSourceCode()
-                .getText(pNode)
-                .replace(
-                  getIdentifierReplacementPattern(lParameterName),
-                  `$1${normalizeParameterName(lParameterName)}$2`
-                );
+      lProblematicParameterNames.forEach((pProblematicParameterName, pIndex, pAllProblematicParameterNames) => {
+        pContext.report({
+          node: pNode,
+          message: `parameter '{{ identifier }}' should be pascal case and start with a p: '{{ betterIdentifier }}'`,
+          data: {
+            identifier: pProblematicParameterName,
+            betterIdentifier: normalizeParameterName(pProblematicParameterName)
+          },
+          fix: getFixes(pContext, pNode, pAllProblematicParameterNames)
+        });
+      })
 
-              return pFixer.replaceText(pNode, lBetterized);
-            }
-          });
-        }
-      });
     }
 
     //----------------------------------------------------------------------

--- a/test/lib/rules/parameter-pattern.spec.js
+++ b/test/lib/rules/parameter-pattern.spec.js
@@ -117,22 +117,22 @@ ruleTester.run("parameter-pattern", rule, {
       ],
       output: "function doSomething(pParam) { const lConst=pParam }"
     },
-    // {
-    //   code:
-    //     "function doSomething(param, secondParam) { const lConst=param*secondParam }",
-    //   errors: [
-    //     {
-    //       message: `parameter 'param' should be pascal case and start with a p: 'pParam'`,
-    //       type: "FunctionDeclaration"
-    //     },
-    //     {
-    //       message: `parameter 'secondParam' should be pascal case and start with a p: 'pSecondParam'`,
-    //       type: "FunctionDeclaration"
-    //     }
-    //   ],
-    //   output:
-    //     "function doSomething(pParam, pSecondParam) { const lConst=pParam*pSecondParam }"
-    // },
+    {
+      code:
+        "function doSomething(param, secondParam) { const lConst=param*secondParam }",
+      errors: [
+        {
+          message: `parameter 'param' should be pascal case and start with a p: 'pParam'`,
+          type: "FunctionDeclaration"
+        },
+        {
+          message: `parameter 'secondParam' should be pascal case and start with a p: 'pSecondParam'`,
+          type: "FunctionDeclaration"
+        }
+      ],
+      output:
+        "function doSomething(pParam, pSecondParam) { const lConst=pParam*pSecondParam }"
+    },
     {
       code:
         "function doSomething(pParam, secondParam) { const lConst=pParam*secondParam }",


### PR DESCRIPTION
## Description, Motivation and Context

This case:
```javascript
function(first, second, third) {}
```

got auto-fixed to 
```javascript
function(pFirst, second, third) {}
```

After this PR it gets auto-fixed to
```javascript
function(pFirst, pSecond, pThird) {}
```


## How Has This Been Tested?

* Additional unit test
* green ci 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
