### PR TITLE
feature(parameter-pattern): improve fixer to handle snake_case and UPPER_SNAKE

### DIFF
--- a/lib/rules/parameter-pattern.js
+++ b/lib/rules/parameter-pattern.js
@@ -1,7 +1,8 @@
 const _get = require("lodash.get");
 const {
   getValidParameterPattern,
-  getIdentifierReplacementPattern
+  getIdentifierReplacementPattern,
+  getValidConstantPattern
 } = require("./pattern-utl");
 /**
  * @fileoverview Enforce function parameters to adhere to a pattern
@@ -11,12 +12,31 @@ const {
 function getParameterName(pParam) {
   return _get(pParam, "name", _get(pParam, "left.name", "pOK"));
 }
-
-function normalizeParameterName(pString) {
-  return `p${pString
+function toInitCaps(pString) {
+  return pString
     .slice(0, 1)
     .toLocaleUpperCase()
-    .concat(pString.slice(1))}`;
+    .concat(
+      // maybe not such a hot idea to use a function named after
+      // a valid constant pattern, but otoh it's a perfect fit
+      // maybe rename that function so it's usable in 2 spots? Copy?
+      pString.slice(1).match(getValidConstantPattern())
+        ? pString.slice(1).toLocaleLowerCase()
+        : pString.slice(1)
+    );
+}
+// wanted to use sindresorhus/camelize for this, but that is not unicode
+// compliant yet
+// handles snake_case and SNAKED_ALL_CAPS
+function toPascalCase(pString) {
+  return pString
+    .split("_")
+    .map(toInitCaps)
+    .join("");
+}
+
+function normalizeParameterName(pString) {
+  return `p${toPascalCase(pString)}`;
 }
 
 function parameterNameIsValid(pString) {
@@ -31,12 +51,12 @@ function getFixes(pContext, pNode, pProblematicParameterNames, pFire) {
   if (pFire) {
     return pFixer => {
       let lBetterized = pProblematicParameterNames.reduce(
-          (pSource, pProblematicParameterName) =>
-              pSource.replace(
-                  getIdentifierReplacementPattern(pProblematicParameterName),
-                  `$1${normalizeParameterName(pProblematicParameterName)}$2`
-              ),
-          pContext.getSourceCode().getText(pNode)
+        (pSource, pProblematicParameterName) =>
+          pSource.replace(
+            getIdentifierReplacementPattern(pProblematicParameterName),
+            `$1${normalizeParameterName(pProblematicParameterName)}$2`
+          ),
+        pContext.getSourceCode().getText(pNode)
       );
 
       return pFixer.replaceText(pNode, lBetterized);
@@ -63,18 +83,26 @@ module.exports = {
         .map(getParameterName)
         .filter(pParameterName => !parameterNameIsValid(pParameterName));
 
-      lProblematicParameterNames.forEach((pProblematicParameterName, pIndex, pAllProblematicParameterNames) => {
-        pContext.report({
-          node: pNode,
-          message: `parameter '{{ identifier }}' should be pascal case and start with a p: '{{ betterIdentifier }}'`,
-          data: {
-            identifier: pProblematicParameterName,
-            betterIdentifier: normalizeParameterName(pProblematicParameterName)
-          },
-          fix: getFixes(pContext, pNode, pAllProblematicParameterNames, pIndex === 0)
-        });
-      })
-
+      lProblematicParameterNames.forEach(
+        (pProblematicParameterName, pIndex, pAllProblematicParameterNames) => {
+          pContext.report({
+            node: pNode,
+            message: `parameter '{{ identifier }}' should be pascal case and start with a p: '{{ betterIdentifier }}'`,
+            data: {
+              identifier: pProblematicParameterName,
+              betterIdentifier: normalizeParameterName(
+                pProblematicParameterName
+              )
+            },
+            fix: getFixes(
+              pContext,
+              pNode,
+              pAllProblematicParameterNames,
+              pIndex === 0
+            )
+          });
+        }
+      );
     }
 
     //----------------------------------------------------------------------

--- a/test/lib/rules/parameter-pattern.spec.js
+++ b/test/lib/rules/parameter-pattern.spec.js
@@ -178,6 +178,37 @@ if (nodeVersionIsRecentEnough()) {
         ],
         output: "const f = (pФункцияПараметр) => { }"
       },
+      // replace snakes
+      {
+        code: "const f = (function_parameter) => { }",
+        errors: [
+          {
+            message: `parameter 'function_parameter' should be pascal case and start with a p: 'pFunctionParameter'`,
+            type: "ArrowFunctionExpression"
+          }
+        ],
+        output: "const f = (pFunctionParameter) => { }"
+      },
+      {
+        code: "const f = (функция_параметр) => { }",
+        errors: [
+          {
+            message: `parameter 'функция_параметр' should be pascal case and start with a p: 'pФункцияПараметр'`,
+            type: "ArrowFunctionExpression"
+          }
+        ],
+        output: "const f = (pФункцияПараметр) => { }"
+      },
+      {
+        code: "const f = (ФУНКЦИЯ_ПАРАМЕТР) => { }",
+        errors: [
+          {
+            message: `parameter 'ФУНКЦИЯ_ПАРАМЕТР' should be pascal case and start with a p: 'pФункцияПараметр'`,
+            type: "ArrowFunctionExpression"
+          }
+        ],
+        output: "const f = (pФункцияПараметр) => { }"
+      },
       // only replace within own scope
       {
         code:


### PR DESCRIPTION
## Description, motivation & context

See title - so the auto fixer is more useful for those cases as well

```javascript
function doStuff(THIS_IS_A_PARAMETER, bunch_of_options = {}) {
   return THIS_IS_A_PARAMETER*(bunch_of_options.multiplier||1)
}
```

will be properly auto corrected to

```javascript
function doStuff(pThisIsAParameter, pBunchOfOptions = {}) {
   return pThisIsAParameter*(pBunchOfOptions.multiplier||1)
}
```

## How Has This Been Tested?

additional unit tests, automated non-regression tests, green ci


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](.//blob/master/.github/CONTRIBUTING.md).
