### PR TITLE
refactor: replaces own pascal case function with sindresorhus/camelcase

### DIFF
--- a/lib/rules/parameter-pattern.js
+++ b/lib/rules/parameter-pattern.js
@@ -1,8 +1,8 @@
+const camelcase = require("camelcase");
 const _get = require("lodash.get");
 const {
   getValidParameterPattern,
   getIdentifierReplacementPattern,
-  getValidConstantPattern,
 } = require("./pattern-utl");
 /**
  * @fileoverview Enforce function parameters to adhere to a pattern
@@ -12,28 +12,9 @@ const {
 function getParameterName(pParam) {
   return _get(pParam, "name", _get(pParam, "left.name", "pOK"));
 }
-function toInitCaps(pString) {
-  return pString
-    .slice(0, 1)
-    .toLocaleUpperCase()
-    .concat(
-      // maybe not such a hot idea to use a function named after
-      // a valid constant pattern, but otoh it's a perfect fit
-      // maybe rename that function so it's usable in 2 spots? Copy?
-      pString.slice(1).match(getValidConstantPattern())
-        ? pString.slice(1).toLocaleLowerCase()
-        : pString.slice(1)
-    );
-}
-// wanted to use sindresorhus/camelize for this, but that is not unicode
-// compliant yet
-// handles snake_case and SNAKED_ALL_CAPS
-function toPascalCase(pString) {
-  return pString.split("_").map(toInitCaps).join("");
-}
 
 function normalizeParameterName(pString) {
-  return `p${toPascalCase(pString)}`;
+  return `p${camelcase(pString, { pascalCase: true })}`;
 }
 
 function parameterNameIsValid(pString) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "version": "npm-run-all check depcruise:graph scm:stage"
   },
   "dependencies": {
+    "camelcase": "6.0.0",
     "decamelize": "4.0.0",
     "lodash.get": "4.4.2"
   },


### PR DESCRIPTION
## Description

Replaces the hand-rolled to-pascal-case function with a readily available one to reduce maintenance/ increase reliability.

## Motivation and Context

We rolled our own because sindresorhus/camelcase didn't support unicode yet - but nowadays it does (since March/ April 2019 when [this PR](https://github.com/sindresorhus/camelcase/pull/62) got merged & released).

## How Has This Been Tested?

- [x] automated non-regression tests


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](../blob/master/.github/CONTRIBUTING.md).
