### PR TITLE
refactor: use constants instead of functions for patterns, where possible

### DIFF
--- a/lib/rules/global-constant-pattern.js
+++ b/lib/rules/global-constant-pattern.js
@@ -1,11 +1,11 @@
 const _get = require("lodash.get");
 const decamelize = require("decamelize");
 const {
-  getValidConstantPattern,
+  VALID_CONSTANT_PATTERN,
   getIdentifierReplacementPattern,
 } = require("./pattern-utl");
 /**
- * @fileoverview Enforce function parameters to adhere to a pattern
+ * @fileoverview Enforce global constants to adhere to a pattern
  * @author sverweij
  */
 
@@ -22,7 +22,7 @@ function normalizeConstantName(pString) {
 }
 
 function constantNameIsValid(pString) {
-  return pString.match(getValidConstantPattern());
+  return pString.match(VALID_CONSTANT_PATTERN);
 }
 
 function getFixes(pContext, pNode, pProblematicConstantNames, pFire) {

--- a/lib/rules/parameter-pattern.js
+++ b/lib/rules/parameter-pattern.js
@@ -1,7 +1,7 @@
 const camelcase = require("camelcase");
 const _get = require("lodash.get");
 const {
-  getValidParameterPattern,
+  VALID_PARAMETER_PATTERN,
   getIdentifierReplacementPattern,
 } = require("./pattern-utl");
 /**
@@ -18,7 +18,7 @@ function normalizeParameterName(pString) {
 }
 
 function parameterNameIsValid(pString) {
-  return pString.match(getValidParameterPattern());
+  return pString.match(VALID_PARAMETER_PATTERN);
 }
 
 //------------------------------------------------------------------------------

--- a/lib/rules/pattern-utl.js
+++ b/lib/rules/pattern-utl.js
@@ -1,6 +1,5 @@
-function getValidParameterPattern() {
-  return /^(p[\p{Lu}]|_)\S*/u;
-}
+const VALID_PARAMETER_PATTERN = /^(p[\p{Lu}]|_)\S*/u;
+const VALID_CONSTANT_PATTERN = /^[\p{Lu}_][\p{Lu}\p{N}_]*$/u;
 
 function getIdentifierReplacementPattern(pParameterName) {
   return new RegExp(
@@ -9,12 +8,8 @@ function getIdentifierReplacementPattern(pParameterName) {
   );
 }
 
-function getValidConstantPattern() {
-  return /^[\p{Lu}_][\p{Lu}\p{N}_]*$/u;
-}
-
 module.exports = {
-  getValidParameterPattern,
+  VALID_PARAMETER_PATTERN,
+  VALID_CONSTANT_PATTERN,
   getIdentifierReplacementPattern,
-  getValidConstantPattern,
 };


### PR DESCRIPTION
## Description, Motivation and Context

It's not necessary to use function calls when a simple const also suffices.

## How Has This Been Tested?

- [x] automated non-regression tests
- [x] green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](.//blob/master/.github/CONTRIBUTING.md).
