### PR TITLE
feature: makes fix more smartly replace other budapestian patterns

### DIFF
--- a/lib/rules/global-constant-pattern.js
+++ b/lib/rules/global-constant-pattern.js
@@ -1,8 +1,11 @@
 const decamelize = require("decamelize");
 const { getVariableDeclaratorName, isConstDeclaration } = require("./ast-utl");
 const {
-  VALID_GLOBAL_CONSTANT_PATTERN,
   getIdentifierReplacementPattern,
+  VALID_GLOBAL_CONSTANT_PATTERN,
+  VALID_PARAMETER_PATTERN,
+  VALID_LOCAL_VARIABLE_PATTERN,
+  VALID_GLOBAL_VARIABLE_PATTERN,
 } = require("./pattern-utl");
 /**
  * @fileoverview Enforce global constants to adhere to a pattern
@@ -14,7 +17,17 @@ const {
 //------------------------------------------------------------------------------
 
 function normalizeConstantName(pString) {
-  return decamelize(pString).toLocaleUpperCase();
+  let lReturnValue = pString;
+
+  if (
+    pString.match(VALID_PARAMETER_PATTERN) ||
+    pString.match(VALID_LOCAL_VARIABLE_PATTERN) ||
+    pString.match(VALID_GLOBAL_VARIABLE_PATTERN)
+  ) {
+    lReturnValue = pString.substring(1);
+  }
+
+  return decamelize(lReturnValue).toLocaleUpperCase();
 }
 
 function constantNameIsValid(pString) {

--- a/lib/rules/global-variable-pattern.js
+++ b/lib/rules/global-variable-pattern.js
@@ -4,6 +4,8 @@ const {
 } = require("./ast-utl");
 const {
   VALID_GLOBAL_VARIABLE_PATTERN,
+  VALID_PARAMETER_PATTERN,
+  VALID_LOCAL_VARIABLE_PATTERN,
   getIdentifierReplacementPattern,
   prefixPascalCaseIdentifier,
 } = require("./pattern-utl");
@@ -18,6 +20,12 @@ const {
 //------------------------------------------------------------------------------
 
 function normalizeGlobalVariableName(pString) {
+  if (
+    pString.match(VALID_PARAMETER_PATTERN) ||
+    pString.match(VALID_LOCAL_VARIABLE_PATTERN)
+  ) {
+    return "g" + pString.substring(1);
+  }
   return prefixPascalCaseIdentifier(pString, "g");
 }
 

--- a/lib/rules/parameter-pattern.js
+++ b/lib/rules/parameter-pattern.js
@@ -2,6 +2,8 @@ const _get = require("lodash.get");
 const { getParameterDeclaratorName } = require("./ast-utl");
 const {
   VALID_PARAMETER_PATTERN,
+  VALID_GLOBAL_VARIABLE_PATTERN,
+  VALID_LOCAL_VARIABLE_PATTERN,
   getIdentifierReplacementPattern,
   prefixPascalCaseIdentifier,
 } = require("./pattern-utl");
@@ -11,6 +13,12 @@ const {
  */
 
 function normalizeParameterName(pString) {
+  if (
+    pString.match(VALID_GLOBAL_VARIABLE_PATTERN) ||
+    pString.match(VALID_LOCAL_VARIABLE_PATTERN)
+  ) {
+    return "p" + pString.substring(1);
+  }
   return prefixPascalCaseIdentifier(pString, "p");
 }
 

--- a/lib/rules/pattern-utl.js
+++ b/lib/rules/pattern-utl.js
@@ -3,6 +3,7 @@ const camelcase = require("camelcase");
 const VALID_PARAMETER_PATTERN = /^(p[\p{Lu}]|_)\S*/u;
 const VALID_GLOBAL_CONSTANT_PATTERN = /^[\p{Lu}_][\p{Lu}\p{N}_]*$/u;
 const VALID_GLOBAL_VARIABLE_PATTERN = /^(g[\p{Lu}]|_)\S*/u;
+const VALID_LOCAL_VARIABLE_PATTERN = /^(l[\p{Lu}])\S*/u;
 
 function getIdentifierReplacementPattern(pIdentifier) {
   return new RegExp(
@@ -19,6 +20,7 @@ module.exports = {
   VALID_PARAMETER_PATTERN,
   VALID_GLOBAL_CONSTANT_PATTERN,
   VALID_GLOBAL_VARIABLE_PATTERN,
+  VALID_LOCAL_VARIABLE_PATTERN,
   getIdentifierReplacementPattern,
   prefixPascalCaseIdentifier,
 };

--- a/test/lib/rules/global-constant-pattern.spec.js
+++ b/test/lib/rules/global-constant-pattern.spec.js
@@ -56,7 +56,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
       ],
       output: `const UPPERCASE = 123; const LOWERCASE = '456'`,
     },
-    // global replace
+    // properly decamlize and then snake case
     {
       code: "const camelCase = 123",
       errors: [
@@ -66,6 +66,42 @@ ruleTester.run("integration: global-constant-pattern", rule, {
         },
       ],
       output: "const CAMEL_CASE = 123",
+    },
+    // when it looks like a local variable, but it is a global constant =>
+    // strip the prefix before de-camelizing & uppering
+    {
+      code: "const lThisIsNotALocalVariable = 123",
+      errors: [
+        {
+          message: `global constant 'lThisIsNotALocalVariable' should be snaked upper case: 'THIS_IS_NOT_A_LOCAL_VARIABLE'`,
+          type: "Program",
+        },
+      ],
+      output: "const THIS_IS_NOT_A_LOCAL_VARIABLE = 123",
+    },
+    // when it looks like a global variable, but it is a global constant =>
+    // strip the prefix before de-camelizing & uppering
+    {
+      code: "const gNotAGlobalVariable = 123",
+      errors: [
+        {
+          message: `global constant 'gNotAGlobalVariable' should be snaked upper case: 'NOT_A_GLOBAL_VARIABLE'`,
+          type: "Program",
+        },
+      ],
+      output: "const NOT_A_GLOBAL_VARIABLE = 123",
+    },
+    // when it looks like a parameter, but it is a global constant =>
+    // strip the prefix before de-camelizing & uppering
+    {
+      code: "const pNotAParameter = 123",
+      errors: [
+        {
+          message: `global constant 'pNotAParameter' should be snaked upper case: 'NOT_A_PARAMETER'`,
+          type: "Program",
+        },
+      ],
+      output: "const NOT_A_PARAMETER = 123",
     },
     // global replace
     {

--- a/test/lib/rules/global-variable-pattern.spec.js
+++ b/test/lib/rules/global-variable-pattern.spec.js
@@ -101,7 +101,7 @@ ruleTester.run("integration: global-variable-pattern", rule, {
       ],
       output: "var gUppercase = 123; var gLowercase = '456'",
     },
-    // global replace
+    // upper snake case handling
     {
       code: "let SNAKE_CASE = 123",
       errors: [
@@ -121,6 +121,48 @@ ruleTester.run("integration: global-variable-pattern", rule, {
         },
       ],
       output: "var gSnakeCase = 123",
+    },
+    // if it looks like a local variable, but it's global => just replace the prefix
+    {
+      code: "let lThisIsAGlobal = 123",
+      errors: [
+        {
+          message: `global variable 'lThisIsAGlobal' should be pascal case and start with a g: 'gThisIsAGlobal'`,
+          type: "Program",
+        },
+      ],
+      output: "let gThisIsAGlobal = 123",
+    },
+    {
+      code: "var lThisIsAGlobal = 123",
+      errors: [
+        {
+          message: `global variable 'lThisIsAGlobal' should be pascal case and start with a g: 'gThisIsAGlobal'`,
+          type: "Program",
+        },
+      ],
+      output: "var gThisIsAGlobal = 123",
+    },
+    // if it looks like a parameter, but it's global => just replace the prefix
+    {
+      code: "let pThisIsAGlobal = 123",
+      errors: [
+        {
+          message: `global variable 'pThisIsAGlobal' should be pascal case and start with a g: 'gThisIsAGlobal'`,
+          type: "Program",
+        },
+      ],
+      output: "let gThisIsAGlobal = 123",
+    },
+    {
+      code: "var pThisIsAGlobal = 123",
+      errors: [
+        {
+          message: `global variable 'pThisIsAGlobal' should be pascal case and start with a g: 'gThisIsAGlobal'`,
+          type: "Program",
+        },
+      ],
+      output: "var gThisIsAGlobal = 123",
     },
     // global replace
     {

--- a/test/lib/rules/parameter-pattern.spec.js
+++ b/test/lib/rules/parameter-pattern.spec.js
@@ -144,6 +144,28 @@ ruleTester.run("integration: parameter-pattern", rule, {
       output:
         "function doSomething(pParam, pSecondParam) { const lConst=pParam*pSecondParam }",
     },
+    // if it's either a local or global variable pattern, just replace
+    // the prefix instead of blindly plonking a p in front of it
+    {
+      code: "function doSomething(lParam) { const lConst=lParam*3 }",
+      errors: [
+        {
+          message: `parameter 'lParam' should be pascal case and start with a p: 'pParam'`,
+          type: "FunctionDeclaration",
+        },
+      ],
+      output: "function doSomething(pParam) { const lConst=pParam*3 }",
+    },
+    {
+      code: "function doSomething(gParam) { const lConst=gParam*3 }",
+      errors: [
+        {
+          message: `parameter 'gParam' should be pascal case and start with a p: 'pParam'`,
+          type: "FunctionDeclaration",
+        },
+      ],
+      output: "function doSomething(pParam) { const lConst=pParam*3 }",
+    },
   ],
 });
 


### PR DESCRIPTION
## Description, Motivation and Context

Currently, when rules fix, they don't take other budapestian patterns into account e.g. if a global constant happens to be named like a global variable (`const gNotAVariable = 481`) it fixes it by decamelizing and upper casing it (`const G_NOT_A_VARIABLE = 481`). This is not typically the desired outcome, as the prefix makes no sense for the global const.

This PR fixes that by taking the budapestian notation prefixes into account when proposing a fix:

| input | ✅ fix proposal after this PR | ❌  fix proposal before this PR
-- | -- | --
|`const gNotAVariable = 481` | `const NOT_A_VARIABLE = 481`| `const G_NOT_A_VARIABLE = 481 `
|`const pNotAParameter = 481` | `const NOT_A_PARAMETER = 481`| `const G_NOT_A_PARAMETER = 481`
|`const lNotAlocal = 481` | `const NOT_A_LOCAL = 481`| `const L_NOT_A_LOCAL = 481`
|`let pNotAParameter` | `let gNotAParameter`| `let gPNotAParameter`
|`let lNotALocal` | `let gNotALocal`| `let gLNotALocal`
|`function doThing(lParam){ return 2*lParam }` | `function doThing (pParam){ return 2*pParam }`| `function doThing (pLParam){ return 2*pLParam }`
|`function doOtherThing (gParam){ return 3*gParam }` | `function doOtherThing (pParam){ return 3*pParam }`| `function doOtherThing (pGParam){ return 3*pGParam }`

## How Has This Been Tested?

- [x] additional automated integration tests
- [x] green ci



## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](.//blob/master/.github/CONTRIBUTING.md).
