### PR TITLE
bugfix(global-const-pattern): limit to a subset

### DIFF
--- a/docs/rules/global-constant-pattern.md
+++ b/docs/rules/global-constant-pattern.md
@@ -1,6 +1,7 @@
 # Enforce global constants adhere to a pattern (global-constant-pattern)
 
-This rule enforces that global _literal_ constants are ALL_CAPS_SNAKE_CASE.
+This rule enforces that global _literal_, _array_, _object_ and _binary expression_
+constants as well as constants that got an identifier assigned are ALL_CAPS_SNAKE_CASE.
 
 🔧 The `--fix option` on the command line renames these constants to adhere to the pattern
 taking existing snake and camel casing into account (someGlobalConstant => SOME_GLOBAL_CONSTANT)
@@ -27,6 +28,12 @@ const severity2coolness = {
   warn: "not cool - fix later",
   error: "very uncool - fix now",
 };
+
+// ass well as binary expressions:
+const dayInSeconds = 24 * 60 * 60;
+
+// ... and identifiers
+const jourEnSecondes = dayInSeconds;
 ```
 
 Examples of **correct** code for this rule:
@@ -48,6 +55,12 @@ const SEVERITY2COOLNESS = {
   warn: "not cool - fix later",
   error: "very uncool - fix now",
 };
+
+// binary expressions are OK too:
+const DAY_IN_SECONDS = 24 * 60 * 60;
+
+// ... and identifiers
+const JOUR_EN_SECONDES = DAY_IN_SECONDS;
 
 // assignments of call expressions to global constants are allowed without
 // them having to be snaked upper case.

--- a/lib/rules/global-constant-pattern-rule.js
+++ b/lib/rules/global-constant-pattern-rule.js
@@ -46,11 +46,12 @@ function getFixes(pContext, pNode, pProblematicConstantNames) {
 function isProblematicConstDeclarator(pDeclarator) {
   return (
     !constantNameIsValid(getVariableDeclaratorName(pDeclarator)) &&
-    ![
-      "CallExpression",
-      "MemberExpression",
-      "NewExpression",
-      "AwaitExpression",
+    [
+      "Literal",
+      "BinaryExpression",
+      "Identifier",
+      "ArrayExpression",
+      "ObjectExpression",
     ].includes(pDeclarator.init.type)
   );
 }

--- a/test/lib/rules/global-constant-pattern-rule.spec.js
+++ b/test/lib/rules/global-constant-pattern-rule.spec.js
@@ -6,16 +6,21 @@ const ruleTester = new RuleTester({
     ecmaVersion: 2018,
   },
 });
+
 ruleTester.run("integration: global-constant-pattern", rule, {
   valid: [
-    "const someModule = require('some-module')",
-    "const expect = require('chai').expect",
-    "const houWoeiRE = new RegExp('houwoei')",
-    "let thing = async () => {}; const godot = thing()",
-    "const CAPITALS = 123",
-    "const CAPITALS = 123, MORE_CAPITALS = '456'",
-    "const THING2SOME_OTHER_THING = { one: 1, two: 2 }",
-    "const AN_ARRAY = ['aap', 'noot', 'mies']",
+    "const callExpression = require('some-module')",
+    "const memberExpression= require('chai').expect",
+    "const newExpression = new RegExp('houwoei')",
+    "const newExpression = new Set()",
+    "const arrowFunctionExpression = async () => {}; const callExpression = thing()",
+    "const someFunction = () => 123",
+    "const someFunction = function(){ return 123 }",
+    "const LITERAL = 123",
+    "const LITERAL = 123, ANOTHER_LITERAL = '456'",
+    "const OBJECT_EXPRESSION = { one: 1, two: 2 }",
+    "const ARRAY_EXPRESSION = ['aap', 'noot', 'mies']",
+    "const OBJECT_EXPRESSION = {}",
     {
       code: "const π = 3.141592653589",
       options: [{ exceptions: ["π", "e"] }],
@@ -66,6 +71,17 @@ ruleTester.run("integration: global-constant-pattern", rule, {
       ],
       output: "const THING = 1; const LOWERCASE = THING",
     },
+    {
+      code: "const π = 3.141592653589",
+      options: [{ exceptions: ["e"] }],
+      errors: [
+        {
+          message: `global constant 'π' should be snaked upper case: 'Π'`,
+          type: "Program",
+        },
+      ],
+      output: "const Π = 3.141592653589",
+    },
     // multi const declaration
     {
       code: "const Uppercase = 123, lowercase = '456'",
@@ -95,6 +111,28 @@ ruleTester.run("integration: global-constant-pattern", rule, {
         },
       ],
       output: `const UPPERCASE = 123; const LOWERCASE = '456'`,
+    },
+    // Array expressions
+    {
+      code: "const arrayExpression = [123, '321']",
+      errors: [
+        {
+          message: `global constant 'arrayExpression' should be snaked upper case: 'ARRAY_EXPRESSION'`,
+          type: "Program",
+        },
+      ],
+      output: `const ARRAY_EXPRESSION = [123, '321']`,
+    },
+    // Object expressions
+    {
+      code: "const objectExpression = {}",
+      errors: [
+        {
+          message: `global constant 'objectExpression' should be snaked upper case: 'OBJECT_EXPRESSION'`,
+          type: "Program",
+        },
+      ],
+      output: `const OBJECT_EXPRESSION = {}`,
     },
     // properly decamlize and then snake case
     {


### PR DESCRIPTION
## Description, Motivation and Context

Previously (v3.0.0) it excluded a few expressions, but this wasn't all things (e.g. it did exclude CallExpressions, but didnt' exclude FunctionExpressions, which it should have). In this fix we take the inclusion approach which is clearer

This bug constituted an unintentional breaking change from 2.3.0 to 3.0.0 where FunctionExpressions were all of a sudden flagged as having an invalid pattern. This PR rolls that back

## How Has This Been Tested?

## How was this tested?

- [x] automated non-regression tests
- [x] green ci
- [x] additional unit tests
- [x] manual testing

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](.//blob/master/.github/CONTRIBUTING.md).
