### PR TITLE
bugfix(global-const-pattern): switch autofixer off

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Then configure the rules you want to use under the rules section.
 | yes           | [budapestian/parameter-pattern](docs/rules/parameter-pattern.md)             | pascal case function parameters and make them start with a `p` |
 | yes           | [budapestian/global-variable-pattern](docs/rules/global-variable-pattern.md) | pascal case global variables and make them start with a `g`    |
 | yes           | [budapestian/local-variable-pattern](docs/rules/local-variable-pattern.md)   | pascal case local variables and make them start with an `l`    |
-| yes           | [budapestian/global-constant-pattern](docs/rules/global-constant-pattern.md) | makes sure global constants are in snaked upper case.          |
+| ~~yes~~ no    | [budapestian/global-constant-pattern](docs/rules/global-constant-pattern.md) | makes sure global constants are in snaked upper case.          |
 
 ## Flare'n status section
 

--- a/docs/rules/global-constant-pattern.md
+++ b/docs/rules/global-constant-pattern.md
@@ -3,8 +3,12 @@
 This rule enforces that global _literal_, _array_, _object_ and _binary expression_
 constants as well as constants that got an identifier assigned are ALL_CAPS_SNAKE_CASE.
 
-🔧 The `--fix option` on the command line renames these constants to adhere to the pattern
-taking existing snake and camel casing into account (someGlobalConstant => SOME_GLOBAL_CONSTANT)
+~~🔧 The `--fix option` on the command line renames these constants to adhere to the pattern
+taking existing snake and camel casing into account (someGlobalConstant => SOME_GLOBAL_CONSTANT)~~
+
+> In version 3.0.2 the fix option for this rule has been switched off
+> temporarily as it was a bit too enthousiastic on occasion. It might return
+> in a future version.
 
 ## Rule Details
 

--- a/lib/rules/global-constant-pattern-rule.js
+++ b/lib/rules/global-constant-pattern-rule.js
@@ -2,7 +2,7 @@ const decamelize = require("decamelize");
 const _get = require("lodash.get");
 const { getVariableDeclaratorName, isConstDeclaration } = require("./ast-utl");
 const {
-  getIdentifierReplacementPattern,
+  // getIdentifierReplacementPattern,
   isNotAnException,
   isOneOfValidPrefixedIdentifiers,
 } = require("./pattern-utl");
@@ -28,20 +28,20 @@ function constantNameIsValid(pString) {
   return VALID_GLOBAL_CONSTANT_PATTERN.test(pString);
 }
 
-function getFixes(pContext, pNode, pProblematicConstantNames) {
-  return (pFixer) => {
-    let lBetterized = pProblematicConstantNames.reduce(
-      (pSource, pProblematicConstantName) =>
-        pSource.replace(
-          getIdentifierReplacementPattern(pProblematicConstantName),
-          `$1${normalizeConstantName(pProblematicConstantName)}$2`
-        ),
-      pContext.getSourceCode().getText(pNode)
-    );
+// function getFixes(pContext, pNode, pProblematicConstantNames) {
+//   return (pFixer) => {
+//     let lBetterized = pProblematicConstantNames.reduce(
+//       (pSource, pProblematicConstantName) =>
+//         pSource.replace(
+//           getIdentifierReplacementPattern(pProblematicConstantName),
+//           `$1${normalizeConstantName(pProblematicConstantName)}$2`
+//         ),
+//       pContext.getSourceCode().getText(pNode)
+//     );
 
-    return pFixer.replaceText(pNode, lBetterized);
-  };
-}
+//     return pFixer.replaceText(pNode, lBetterized);
+//   };
+// }
 
 function isProblematicConstDeclarator(pDeclarator) {
   return (
@@ -77,7 +77,8 @@ function reportProblematicGlobalConstants(
   pProblematicConstants
 ) {
   pProblematicConstants.forEach(
-    (pProblematicConstantName, _pIndex, pAllProblematicConstantNames) => {
+    // (pProblematicConstantName, _pIndex, pAllProblematicConstantNames) => {
+    (pProblematicConstantName) => {
       pContext.report({
         node: pNode,
         message: `global constant '{{ identifier }}' should be snaked upper case: '{{ betterIdentifier }}'`,
@@ -85,7 +86,7 @@ function reportProblematicGlobalConstants(
           identifier: pProblematicConstantName,
           betterIdentifier: normalizeConstantName(pProblematicConstantName),
         },
-        fix: getFixes(pContext, pNode, pAllProblematicConstantNames),
+        // fix: getFixes(pContext, pNode, pAllProblematicConstantNames),
       });
     }
   );
@@ -101,7 +102,8 @@ module.exports = {
       recommended: false,
       url: "https://sverweij.github.io/eslint-plugin-budapestian/rules/global-constant-pattern",
     },
-    fixable: "code",
+    // fixable: "code",
+    fixable: false,
   },
 
   create: (pContext) => {

--- a/test/lib/rules/global-constant-pattern-rule.spec.js
+++ b/test/lib/rules/global-constant-pattern-rule.spec.js
@@ -30,7 +30,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
   invalid: [
     {
       code: "const lowercase = 123",
-      output: "const LOWERCASE = 123",
+      // output: "const LOWERCASE = 123",
       errors: [
         {
           message: `global constant 'lowercase' should be snaked upper case: 'LOWERCASE'`,
@@ -40,7 +40,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     },
     {
       code: "const lowercase = 123",
-      output: "const LOWERCASE = 123",
+      // output: "const LOWERCASE = 123",
       options: [{ exceptions: ["π", "e"] }],
       errors: [
         {
@@ -51,7 +51,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     },
     {
       code: "const lowercase = 1 * 2 * 3",
-      output: "const LOWERCASE = 1 * 2 * 3",
+      // output: "const LOWERCASE = 1 * 2 * 3",
       options: [{ exceptions: ["π", "e"] }],
       errors: [
         {
@@ -62,7 +62,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     },
     {
       code: "const THING = 1; const lowercase = THING",
-      output: "const THING = 1; const LOWERCASE = THING",
+      // output: "const THING = 1; const LOWERCASE = THING",
       options: [{ exceptions: ["π", "e"] }],
       errors: [
         {
@@ -73,7 +73,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     },
     {
       code: "const π = 3.141592653589",
-      output: "const Π = 3.141592653589",
+      // output: "const Π = 3.141592653589",
       options: [{ exceptions: ["e"] }],
       errors: [
         {
@@ -85,7 +85,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // multi const declaration
     {
       code: "const Uppercase = 123, lowercase = '456'",
-      output: "const UPPERCASE = 123, LOWERCASE = '456'",
+      // output: "const UPPERCASE = 123, LOWERCASE = '456'",
       errors: [
         {
           message: `global constant 'Uppercase' should be snaked upper case: 'UPPERCASE'`,
@@ -100,7 +100,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // multiple const declarations
     {
       code: "const Uppercase = 123; const lowercase = '456'",
-      output: `const UPPERCASE = 123; const LOWERCASE = '456'`,
+      // output: `const UPPERCASE = 123; const LOWERCASE = '456'`,
       errors: [
         {
           message: `global constant 'Uppercase' should be snaked upper case: 'UPPERCASE'`,
@@ -115,7 +115,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // Array expressions
     {
       code: "const arrayExpression = [123, '321']",
-      output: `const ARRAY_EXPRESSION = [123, '321']`,
+      // output: `const ARRAY_EXPRESSION = [123, '321']`,
       errors: [
         {
           message: `global constant 'arrayExpression' should be snaked upper case: 'ARRAY_EXPRESSION'`,
@@ -126,7 +126,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // Object expressions
     {
       code: "const objectExpression = {}",
-      output: `const OBJECT_EXPRESSION = {}`,
+      // output: `const OBJECT_EXPRESSION = {}`,
       errors: [
         {
           message: `global constant 'objectExpression' should be snaked upper case: 'OBJECT_EXPRESSION'`,
@@ -137,7 +137,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // properly decamlize and then snake case
     {
       code: "const camelCase = 123",
-      output: "const CAMEL_CASE = 123",
+      // output: "const CAMEL_CASE = 123",
       errors: [
         {
           message: `global constant 'camelCase' should be snaked upper case: 'CAMEL_CASE'`,
@@ -149,7 +149,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // strip the prefix before de-camelizing & uppering
     {
       code: "const lThisIsNotALocalVariable = 123",
-      output: "const THIS_IS_NOT_A_LOCAL_VARIABLE = 123",
+      // output: "const THIS_IS_NOT_A_LOCAL_VARIABLE = 123",
       errors: [
         {
           message: `global constant 'lThisIsNotALocalVariable' should be snaked upper case: 'THIS_IS_NOT_A_LOCAL_VARIABLE'`,
@@ -161,7 +161,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // strip the prefix before de-camelizing & uppering
     {
       code: "const gNotAGlobalVariable = 123",
-      output: "const NOT_A_GLOBAL_VARIABLE = 123",
+      // output: "const NOT_A_GLOBAL_VARIABLE = 123",
       errors: [
         {
           message: `global constant 'gNotAGlobalVariable' should be snaked upper case: 'NOT_A_GLOBAL_VARIABLE'`,
@@ -173,7 +173,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // strip the prefix before de-camelizing & uppering
     {
       code: "const pNotAParameter = 123",
-      output: "const NOT_A_PARAMETER = 123",
+      // output: "const NOT_A_PARAMETER = 123",
       errors: [
         {
           message: `global constant 'pNotAParameter' should be snaked upper case: 'NOT_A_PARAMETER'`,
@@ -184,8 +184,8 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     // global replace
     {
       code: "const lowercase = 123; function f (pBla) { return lowercase * pBla }",
-      output:
-        "const LOWERCASE = 123; function f (pBla) { return LOWERCASE * pBla }",
+      // output:
+      //   "const LOWERCASE = 123; function f (pBla) { return LOWERCASE * pBla }",
       errors: [
         {
           message: `global constant 'lowercase' should be snaked upper case: 'LOWERCASE'`,
@@ -206,7 +206,7 @@ ruleTester.run("integration: global-constant-pattern - unicode edition", rule, {
   invalid: [
     {
       code: "const константаУлучшение = 123",
-      output: "const КОНСТАНТА_УЛУЧШЕНИЕ = 123",
+      // output: "const КОНСТАНТА_УЛУЧШЕНИЕ = 123",
       errors: [
         {
           message: `global constant 'константаУлучшение' should be snaked upper case: 'КОНСТАНТА_УЛУЧШЕНИЕ'`,


### PR DESCRIPTION
## Description, Motivation and Context

Switch the auto fixer for the global-const-pattern rule off as it was a bit too enthousiastic on occasion. Code needs a safer way to fix things

## How Has This Been Tested?

- [x] green ci
- [x] adapted automated tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](.//blob/master/.github/CONTRIBUTING.md).
