### PR TITLE
bugfix(global-const-pattern): also recognize exported global consts BREAKING

### DIFF
--- a/docs/rules/global-constant-pattern.md
+++ b/docs/rules/global-constant-pattern.md
@@ -38,6 +38,9 @@ const dayInSeconds = 24 * 60 * 60;
 
 // ... and identifiers
 const jourEnSecondes = dayInSeconds;
+
+// the rule also extends to exported constants
+export const exportedGlobalConst = "something";
 ```
 
 Examples of **correct** code for this rule:
@@ -65,6 +68,9 @@ const DAY_IN_SECONDS = 24 * 60 * 60;
 
 // ... and identifiers
 const JOUR_EN_SECONDES = DAY_IN_SECONDS;
+
+// exported consts are taken into account as well
+export const EXPORTED_GLOBAL_CONST = "something";
 
 // assignments of call expressions to global constants are allowed without
 // them having to be snaked upper case.

--- a/lib/rules/ast-utl.js
+++ b/lib/rules/ast-utl.js
@@ -32,10 +32,15 @@ function isBlockScopedVarDeclaration(pNode) {
   return isLetDeclaration(pNode) || isConstDeclaration(pNode);
 }
 
+function isExportNamedDeclaration(pNode) {
+  return pNode.type === "ExportNamedDeclaration";
+}
+
 module.exports = {
   getVariableDeclaratorName,
   getParameterDeclaratorName,
   isConstDeclaration,
   isLetOrVarDeclaration,
   isBlockScopedVarDeclaration,
+  isExportNamedDeclaration,
 };

--- a/lib/rules/global-constant-pattern-rule.js
+++ b/lib/rules/global-constant-pattern-rule.js
@@ -1,6 +1,10 @@
 const decamelize = require("decamelize");
 const _get = require("lodash.get");
-const { getVariableDeclaratorName, isConstDeclaration } = require("./ast-utl");
+const {
+  getVariableDeclaratorName,
+  isConstDeclaration,
+  isExportNamedDeclaration,
+} = require("./ast-utl");
 const {
   // getIdentifierReplacementPattern,
   isNotAnException,
@@ -57,8 +61,13 @@ function isProblematicConstDeclarator(pDeclarator) {
 }
 
 function getProblematicGlobalConstantsFromBody(pBody, pAllowedConstantNames) {
-  return pBody
-    .filter(isConstDeclaration)
+  const lExportConsts = pBody
+    .filter(isExportNamedDeclaration)
+    .map((pNode) => pNode.declaration)
+    .filter(isConstDeclaration);
+  const lGlobaConsts = pBody.filter(isConstDeclaration);
+  return lExportConsts
+    .concat(lGlobaConsts)
     .reduce(
       (pAll, pConstantDeclaration) =>
         pAll.concat(

--- a/test/lib/rules/global-constant-pattern-rule.spec.js
+++ b/test/lib/rules/global-constant-pattern-rule.spec.js
@@ -4,6 +4,7 @@ const RuleTester = require("eslint").RuleTester;
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2018,
+    sourceType: "module",
   },
 });
 
@@ -210,6 +211,27 @@ ruleTester.run("integration: global-constant-pattern - unicode edition", rule, {
       errors: [
         {
           message: `global constant 'константаУлучшение' should be snaked upper case: 'КОНСТАНТА_УЛУЧШЕНИЕ'`,
+          type: "Program",
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run("integration: global-constant-pattern - export edition", rule, {
+  valid: ['export const MY_GLOBAL_CONSTANT = "something";'],
+
+  invalid: [
+    {
+      code: 'export const myGlobalConstant = "something"; export const anOtherGlobalConst = "something else"',
+      // output: 'const MY_GLOBAL_CONSTANT = "something"',
+      errors: [
+        {
+          message: `global constant 'myGlobalConstant' should be snaked upper case: 'MY_GLOBAL_CONSTANT'`,
+          type: "Program",
+        },
+        {
+          message: `global constant 'anOtherGlobalConst' should be snaked upper case: 'AN_OTHER_GLOBAL_CONST'`,
           type: "Program",
         },
       ],


### PR DESCRIPTION
## Description

- adds recognition of exported global consts on the `global-const-pattern` rule

## Motivation and Context

fixes #18 

## How Has This Been Tested?

- [x] green ci
- [x] additional unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](.//blob/master/.github/CONTRIBUTING.md).
