### PR TITLE
Added filter to avoid constant-pattern error on null declaration

### DIFF
--- a/lib/rules/global-constant-pattern-rule.js
+++ b/lib/rules/global-constant-pattern-rule.js
@@ -63,7 +63,7 @@ function getProblematicGlobalConstantsFromBody(pBody, pAllowedConstantNames) {
   const lExportConsts = pBody
     .filter(isExportNamedDeclaration)
     .map((pNode) => pNode.declaration)
-    .filter((declaration) => declaration !== null)
+    .filter((pDeclaration) => pDeclaration !== null)
     .filter(isConstDeclaration);
   const lGlobaConsts = pBody.filter(isConstDeclaration);
   return lExportConsts

--- a/lib/rules/global-constant-pattern-rule.js
+++ b/lib/rules/global-constant-pattern-rule.js
@@ -63,6 +63,7 @@ function getProblematicGlobalConstantsFromBody(pBody, pAllowedConstantNames) {
   const lExportConsts = pBody
     .filter(isExportNamedDeclaration)
     .map((pNode) => pNode.declaration)
+    .filter((declaration) => declaration !== null)
     .filter(isConstDeclaration);
   const lGlobaConsts = pBody.filter(isConstDeclaration);
   return lExportConsts

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mocha": "10.0.0",
     "npm-run-all": "4.1.5",
     "prettier": "2.7.1",
+    "typescript": "4.8.4",
     "upem": "7.3.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "decamelize": "^4.0.0"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "5.39.0",
     "c8": "7.12.0",
     "chai": "4.3.6",
     "dependency-cruiser": "11.15.0",

--- a/test/lib/rules/global-constant-pattern-rule.spec.js
+++ b/test/lib/rules/global-constant-pattern-rule.spec.js
@@ -2,6 +2,7 @@ const rule = require("../../../lib/rules/global-constant-pattern-rule");
 const RuleTester = require("eslint").RuleTester;
 
 const ruleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: "module",

--- a/test/lib/rules/global-constant-pattern-rule.spec.js
+++ b/test/lib/rules/global-constant-pattern-rule.spec.js
@@ -17,6 +17,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     "const arrowFunctionExpression = async () => {}; const callExpression = thing()",
     "const someFunction = () => 123",
     "const someFunction = function(){ return 123 }",
+    "type SomeType = string",
     "const LITERAL = 123",
     "const LITERAL = 123, ANOTHER_LITERAL = '456'",
     "const OBJECT_EXPRESSION = { one: 1, two: 2 }",


### PR DESCRIPTION
## Description

We may have found an unexpected bug while trying to export a type declaration that was written into our `types.ts` through our `index.ts`.

## Motivation and context

Getting the following error when trying to export a type declaration from our package:
```
TypeError: Cannot read properties of null (reading 'type')
Occurred while linting index.ts:1
Rule: "budapestian/global-constant-pattern"
    at isConstDeclaration (.pnpm/eslint-plugin-budapestian@4.0.0_eslint@8.24.0/node_modules/eslint-plugin-budapestian/lib/rules/ast-utl.js:16:16)
    at Array.filter (<anonymous>)
    at getProblematicGlobalConstantsFromBody (node_modules/.pnpm/eslint-plugin-budapestian@4.0.0_eslint@8.24.0/node_modules/eslint-plugin-budapestian/lib/rules/global-constant-pattern-rule.js:68:31)
    at Program (node_modules/.pnpm/eslint-plugin-budapestian@4.0.0_eslint@8.24.0/node_modules/eslint-plugin-budapestian/lib/rules/global-constant-pattern-rule.js:123:39)
    at ruleErrorHandler (node_modules/.pnpm/eslint@8.24.0/node_modules/eslint/lib/linter/linter.js:1114:28)
    at node_modules/.pnpm/eslint@8.24.0/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (node_modules/.pnpm/eslint@8.24.0/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (node_modules/.pnpm/eslint@8.24.0/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (node_modules/.pnpm/eslint@8.24.0/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
```

### index.ts
```
export { SomeType } from './types';
```

### types.ts
```
import { SomePackageType } from 'somepackage';

export type SomeType = string | SomePackageType;
```

## How Has This Been Tested?

Existing tests pass with the new change

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](.//blob/master/.github/CONTRIBUTING.md).
