### PR TITLE
test: also test all rules with the typescript-eslint parser

### DIFF
--- a/test/lib/rules/global-constant-pattern-rule.spec.js
+++ b/test/lib/rules/global-constant-pattern-rule.spec.js
@@ -1,7 +1,7 @@
 const rule = require("../../../lib/rules/global-constant-pattern-rule");
 const RuleTester = require("eslint").RuleTester;
 
-const ruleTester = new RuleTester({
+const ruleTesterTypeScriptParser = new RuleTester({
   parser: require.resolve("@typescript-eslint/parser"),
   parserOptions: {
     ecmaVersion: 2018,
@@ -9,7 +9,14 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run("integration: global-constant-pattern", rule, {
+const ruleTesterDefaultParser = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: "module",
+  },
+});
+
+const GLOBAL_CONSTANT_CASES = {
   valid: [
     "const callExpression = require('some-module')",
     "const memberExpression= require('chai').expect",
@@ -18,7 +25,7 @@ ruleTester.run("integration: global-constant-pattern", rule, {
     "const arrowFunctionExpression = async () => {}; const callExpression = thing()",
     "const someFunction = () => 123",
     "const someFunction = function(){ return 123 }",
-    "type SomeType = string",
+
     "const LITERAL = 123",
     "const LITERAL = 123, ANOTHER_LITERAL = '456'",
     "const OBJECT_EXPRESSION = { one: 1, two: 2 }",
@@ -197,9 +204,30 @@ ruleTester.run("integration: global-constant-pattern", rule, {
       ],
     },
   ],
-});
+};
 
-ruleTester.run("integration: global-constant-pattern - unicode edition", rule, {
+ruleTesterTypeScriptParser.run(
+  "integration: global-constant-pattern - TypeScript parser",
+  rule,
+  GLOBAL_CONSTANT_CASES
+);
+
+ruleTesterTypeScriptParser.run(
+  "integration: global-constant-pattern - TypeScript specials - TypeScript parser",
+  rule,
+  {
+    valid: ["type SomeType = string"],
+    invalid: [],
+  }
+);
+
+ruleTesterDefaultParser.run(
+  "integration: global-constant-pattern - default parser",
+  rule,
+  GLOBAL_CONSTANT_CASES
+);
+
+const GLOBAL_CONSTANT_UNICODE_CASES = {
   valid: [
     "const какойТоМодуль = require('some-module')",
     "const ВЕРХНИЙ_РЕГИСТР = 123",
@@ -218,9 +246,21 @@ ruleTester.run("integration: global-constant-pattern - unicode edition", rule, {
       ],
     },
   ],
-});
+};
 
-ruleTester.run("integration: global-constant-pattern - export edition", rule, {
+ruleTesterTypeScriptParser.run(
+  "integration: global-constant-pattern - unicode edition - TypeScript parser",
+  rule,
+  GLOBAL_CONSTANT_UNICODE_CASES
+);
+
+ruleTesterDefaultParser.run(
+  "integration: global-constant-pattern - unicode edition - default parser",
+  rule,
+  GLOBAL_CONSTANT_UNICODE_CASES
+);
+
+const GLOBAL_CONSTANT_EXPORT_PATTERN_CASES = {
   valid: ['export const MY_GLOBAL_CONSTANT = "something";'],
 
   invalid: [
@@ -239,4 +279,16 @@ ruleTester.run("integration: global-constant-pattern - export edition", rule, {
       ],
     },
   ],
-});
+};
+
+ruleTesterTypeScriptParser.run(
+  "integration: global-constant-pattern - export edition - TypeScript parser",
+  rule,
+  GLOBAL_CONSTANT_EXPORT_PATTERN_CASES
+);
+
+ruleTesterDefaultParser.run(
+  "integration: global-constant-pattern - export edition - default parser",
+  rule,
+  GLOBAL_CONSTANT_EXPORT_PATTERN_CASES
+);

--- a/test/lib/rules/global-variable-pattern-rule.spec.js
+++ b/test/lib/rules/global-variable-pattern-rule.spec.js
@@ -1,12 +1,20 @@
 const rule = require("../../../lib/rules/global-variable-pattern-rule");
 const RuleTester = require("eslint").RuleTester;
 
-const ruleTester = new RuleTester({
+const ruleTesterTypeScriptParser = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
   parserOptions: {
     ecmaVersion: 2018,
   },
 });
-ruleTester.run("integration: global-variable-pattern", rule, {
+
+const ruleTesterDefaultParser = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+  },
+});
+
+const GLOBAL_VARIABLE_CASES = {
   valid: [
     "let someModule = require('some-module')",
     "let gGlobalVariable;",
@@ -239,9 +247,21 @@ ruleTester.run("integration: global-variable-pattern", rule, {
       ],
     },
   ],
-});
+};
 
-ruleTester.run("integration: global-constant-pattern - unicode edition", rule, {
+ruleTesterTypeScriptParser.run(
+  "integration: global-variable-pattern - TypeScript parser",
+  rule,
+  GLOBAL_VARIABLE_CASES
+);
+
+ruleTesterDefaultParser.run(
+  "integration: global-variable-pattern - default parser",
+  rule,
+  GLOBAL_VARIABLE_CASES
+);
+
+const GLOBAL_VARIABLE_UNICODE_CASES = {
   valid: [
     "let какойТоМодуль = require('some-module')",
     "let gПаскальКейс = 123",
@@ -273,4 +293,16 @@ ruleTester.run("integration: global-constant-pattern - unicode edition", rule, {
       ],
     },
   ],
-});
+};
+
+ruleTesterTypeScriptParser.run(
+  "integration: global-constant-pattern - unicode edition - TypeScript parser",
+  rule,
+  GLOBAL_VARIABLE_UNICODE_CASES
+);
+
+ruleTesterDefaultParser.run(
+  "integration: global-constant-pattern - unicode edition - default parser",
+  rule,
+  GLOBAL_VARIABLE_UNICODE_CASES
+);

--- a/test/lib/rules/local-variable-pattern-rule.spec.js
+++ b/test/lib/rules/local-variable-pattern-rule.spec.js
@@ -1,256 +1,272 @@
 const rule = require("../../../lib/rules/local-variable-pattern-rule");
 const RuleTester = require("eslint").RuleTester;
 
-const ruleTester = new RuleTester({
+const ruleTesterTypeScriptParser = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
   parserOptions: {
     ecmaVersion: 2018,
   },
 });
-ruleTester.run(
-  "integration: local-variable-pattern - regular block scope variables",
-  rule,
-  {
-    valid: [
-      "{ let thing = require('thing') }",
-      "{ let thing = require('thing').halikidee }",
-      "{ let thing = new RegExp('thing') }",
-      "function doSomething() { let lVariable }",
-      "{ let lVariable }",
-      "function doSomething() { if(true) {let lVariable} }",
-      "function doSomething() { let lVariable = 123}",
-      "function doSomething() { let lVariable, lSecondVariable, lThirdVariable = 123}",
-      "{ const lVariable = 123}",
-      "function doSomething() { const lVariable = 123}",
-      "function doSomething() { const lVariable = 123, lSecondVariable = 456, lThirdVariable = 789}",
-      "const GLOBAL_CONST = 1", // different rules for global consts
-      "let gGlobalVariable = 'globally ok'", // ... and for global variables
-    ],
 
-    invalid: [
-      // uninitialized
-      {
-        code: "{ let variable;}",
-        output: "{ let lVariable;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // initialized with a single literal value
-      {
-        code: "{ let variable = 481;}",
-        output: "{ let lVariable = 481;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      {
-        code: "{ const variable = 481;}",
-        output: "{ const lVariable = 481;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // initialized with an array
-      {
-        code: "{ let variable = ['this', 'is', 'an', 'array'];}",
-        output: "{ let lVariable = ['this', 'is', 'an', 'array'];}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      {
-        code: "{ const variable = ['this', 'is', 'an', 'array'];}",
-        output: "{ const lVariable = ['this', 'is', 'an', 'array'];}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // initialized with an object
-      {
-        code: "{ let variable = {};}",
-        output: "{ let lVariable = {};}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      {
-        code: "{ const variable = {};}",
-        output: "{ const lVariable = {};}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // initialized with an binary expression
-      {
-        code: "{ let variable = 1 + 1;}",
-        output: "{ let lVariable = 1 + 1;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      {
-        code: "{ const variable = 1 + 1;}",
-        output: "{ const lVariable = 1 + 1;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // initialized with a constant
-      {
-        code: "{ const lThing = 2; let variable = lThing;}",
-        output: "{ const lThing = 2; let lVariable = lThing;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      {
-        code: "{ const lThing = 2; const variable = lThing;}",
-        output: "{ const lThing = 2; const lVariable = lThing;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // smartly replace other budapestian prefixes
-      {
-        code: "{ let gVariable;}",
-        output: "{ let lVariable;}",
-        errors: [
-          {
-            message: `local variable 'gVariable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      {
-        code: "{ const pVariable = 481;}",
-        output: "{ const lVariable = 481;}",
-        errors: [
-          {
-            message: `local variable 'pVariable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      {
-        code: "function doSomething() { let variable;}",
-        output: "function doSomething() { let lVariable;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // multiple declaration
-      {
-        code: "{ let one, two, three = 123;}",
-        output: "{ let lOne, lTwo, lThree = 123;}",
-        errors: [
-          {
-            message: `local variable 'one' should be pascal case and start with a 'l': 'lOne'`,
-            type: "BlockStatement",
-          },
-          {
-            message: `local variable 'two' should be pascal case and start with a 'l': 'lTwo'`,
-            type: "BlockStatement",
-          },
-          {
-            message: `local variable 'three' should be pascal case and start with a 'l': 'lThree'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // multiple declarations
-      {
-        code: "{ let one; let two; let three;}",
-        output: "{ let lOne; let lTwo; let lThree;}",
-        errors: [
-          {
-            message: `local variable 'one' should be pascal case and start with a 'l': 'lOne'`,
-            type: "BlockStatement",
-          },
-          {
-            message: `local variable 'two' should be pascal case and start with a 'l': 'lTwo'`,
-            type: "BlockStatement",
-          },
-          {
-            message: `local variable 'three' should be pascal case and start with a 'l': 'lThree'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      {
-        code: "{ const one = 1; const two = 2; const three = 3;}",
-        output: "{ const lOne = 1; const lTwo = 2; const lThree = 3;}",
-        errors: [
-          {
-            message: `local variable 'one' should be pascal case and start with a 'l': 'lOne'`,
-            type: "BlockStatement",
-          },
-          {
-            message: `local variable 'two' should be pascal case and start with a 'l': 'lTwo'`,
-            type: "BlockStatement",
-          },
-          {
-            message: `local variable 'three' should be pascal case and start with a 'l': 'lThree'`,
-            type: "BlockStatement",
-          },
-        ],
-      },
-      // leave variables outside the block scope alone
-      {
-        code: "let variable = '123'; function doSomething() { let variable = 123; for (let counter = 1; counter < 10; counter++) { variable += variable}; return variable;}",
-        output:
-          "let variable = '123'; function doSomething() { let lVariable = 123; for (let counter = 1; counter < 10; counter++) { lVariable += lVariable}; return lVariable;}",
-        errors: [
-          {
-            message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
-            type: "BlockStatement",
-          },
-          {
-            message: `local variable 'counter' should be pascal case and start with a 'l': 'lCounter'`,
-            type: "ForStatement",
-          },
-        ],
-      },
-    ],
-  }
+const ruleTesterDefaultParser = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+  },
+});
+
+const LOCAL_VARIABLE_BLOCK_SCOPE_CASES = {
+  valid: [
+    "{ let thing = require('thing') }",
+    "{ let thing = require('thing').halikidee }",
+    "{ let thing = new RegExp('thing') }",
+    "function doSomething() { let lVariable }",
+    "{ let lVariable }",
+    "function doSomething() { if(true) {let lVariable} }",
+    "function doSomething() { let lVariable = 123}",
+    "function doSomething() { let lVariable, lSecondVariable, lThirdVariable = 123}",
+    "{ const lVariable = 123}",
+    "function doSomething() { const lVariable = 123}",
+    "function doSomething() { const lVariable = 123, lSecondVariable = 456, lThirdVariable = 789}",
+    "const GLOBAL_CONST = 1", // different rules for global consts
+    "let gGlobalVariable = 'globally ok'", // ... and for global variables
+  ],
+
+  invalid: [
+    // uninitialized
+    {
+      code: "{ let variable;}",
+      output: "{ let lVariable;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // initialized with a single literal value
+    {
+      code: "{ let variable = 481;}",
+      output: "{ let lVariable = 481;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    {
+      code: "{ const variable = 481;}",
+      output: "{ const lVariable = 481;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // initialized with an array
+    {
+      code: "{ let variable = ['this', 'is', 'an', 'array'];}",
+      output: "{ let lVariable = ['this', 'is', 'an', 'array'];}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    {
+      code: "{ const variable = ['this', 'is', 'an', 'array'];}",
+      output: "{ const lVariable = ['this', 'is', 'an', 'array'];}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // initialized with an object
+    {
+      code: "{ let variable = {};}",
+      output: "{ let lVariable = {};}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    {
+      code: "{ const variable = {};}",
+      output: "{ const lVariable = {};}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // initialized with an binary expression
+    {
+      code: "{ let variable = 1 + 1;}",
+      output: "{ let lVariable = 1 + 1;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    {
+      code: "{ const variable = 1 + 1;}",
+      output: "{ const lVariable = 1 + 1;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // initialized with a constant
+    {
+      code: "{ const lThing = 2; let variable = lThing;}",
+      output: "{ const lThing = 2; let lVariable = lThing;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    {
+      code: "{ const lThing = 2; const variable = lThing;}",
+      output: "{ const lThing = 2; const lVariable = lThing;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // smartly replace other budapestian prefixes
+    {
+      code: "{ let gVariable;}",
+      output: "{ let lVariable;}",
+      errors: [
+        {
+          message: `local variable 'gVariable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    {
+      code: "{ const pVariable = 481;}",
+      output: "{ const lVariable = 481;}",
+      errors: [
+        {
+          message: `local variable 'pVariable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    {
+      code: "function doSomething() { let variable;}",
+      output: "function doSomething() { let lVariable;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // multiple declaration
+    {
+      code: "{ let one, two, three = 123;}",
+      output: "{ let lOne, lTwo, lThree = 123;}",
+      errors: [
+        {
+          message: `local variable 'one' should be pascal case and start with a 'l': 'lOne'`,
+          type: "BlockStatement",
+        },
+        {
+          message: `local variable 'two' should be pascal case and start with a 'l': 'lTwo'`,
+          type: "BlockStatement",
+        },
+        {
+          message: `local variable 'three' should be pascal case and start with a 'l': 'lThree'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // multiple declarations
+    {
+      code: "{ let one; let two; let three;}",
+      output: "{ let lOne; let lTwo; let lThree;}",
+      errors: [
+        {
+          message: `local variable 'one' should be pascal case and start with a 'l': 'lOne'`,
+          type: "BlockStatement",
+        },
+        {
+          message: `local variable 'two' should be pascal case and start with a 'l': 'lTwo'`,
+          type: "BlockStatement",
+        },
+        {
+          message: `local variable 'three' should be pascal case and start with a 'l': 'lThree'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    {
+      code: "{ const one = 1; const two = 2; const three = 3;}",
+      output: "{ const lOne = 1; const lTwo = 2; const lThree = 3;}",
+      errors: [
+        {
+          message: `local variable 'one' should be pascal case and start with a 'l': 'lOne'`,
+          type: "BlockStatement",
+        },
+        {
+          message: `local variable 'two' should be pascal case and start with a 'l': 'lTwo'`,
+          type: "BlockStatement",
+        },
+        {
+          message: `local variable 'three' should be pascal case and start with a 'l': 'lThree'`,
+          type: "BlockStatement",
+        },
+      ],
+    },
+    // leave variables outside the block scope alone
+    {
+      code: "let variable = '123'; function doSomething() { let variable = 123; for (let counter = 1; counter < 10; counter++) { variable += variable}; return variable;}",
+      output:
+        "let variable = '123'; function doSomething() { let lVariable = 123; for (let counter = 1; counter < 10; counter++) { lVariable += lVariable}; return lVariable;}",
+      errors: [
+        {
+          message: `local variable 'variable' should be pascal case and start with a 'l': 'lVariable'`,
+          type: "BlockStatement",
+        },
+        {
+          message: `local variable 'counter' should be pascal case and start with a 'l': 'lCounter'`,
+          type: "ForStatement",
+        },
+      ],
+    },
+  ],
+};
+
+ruleTesterTypeScriptParser.run(
+  "integration: local-variable-pattern - regular block scope variables - TypeScript parser",
+  rule,
+  LOCAL_VARIABLE_BLOCK_SCOPE_CASES
 );
 
-ruleTester.run("integration: local-variable-pattern - for statement", rule, {
+ruleTesterDefaultParser.run(
+  "integration: local-variable-pattern - regular block scope variables - default parser",
+  rule,
+  LOCAL_VARIABLE_BLOCK_SCOPE_CASES
+);
+
+const LOCAL_VARIABLE_FOR_STATEMENT_CASES = {
   valid: [
     "for(let lCounter=0;lCounter<10;lCounter++){var i = lCounter + i}",
     "for(var counter=0;counter<10;counter++){var i = counter + i}",
@@ -278,9 +294,21 @@ ruleTester.run("integration: local-variable-pattern - for statement", rule, {
       ],
     },
   ],
-});
+};
 
-ruleTester.run("integration: local-variable-pattern - for-in statement", rule, {
+ruleTesterTypeScriptParser.run(
+  "integration: local-variable-pattern - for statement - TypeScript parser",
+  rule,
+  LOCAL_VARIABLE_FOR_STATEMENT_CASES
+);
+
+ruleTesterDefaultParser.run(
+  "integration: local-variable-pattern - for statement - default parser",
+  rule,
+  LOCAL_VARIABLE_FOR_STATEMENT_CASES
+);
+
+const LOCAL_VARIABLE_FOR_IN_STATEMENT_CASES = {
   valid: ["for (let lCounter in [7,8,9]){var i = lCounter + i}"],
   invalid: [
     {
@@ -305,36 +333,46 @@ ruleTester.run("integration: local-variable-pattern - for-in statement", rule, {
       ],
     },
   ],
-});
+};
 
-ruleTester.run("integration: local-variable-pattern - for-of statement", rule, {
-  valid: ["for (let lCounter of [7,8,9]){var i = lCounter + i}"],
-  invalid: [
-    {
-      code: "for(let counter of [7,8,9]){}",
-      output: "for(let lCounter of [7,8,9]){}",
-      errors: [
-        {
-          message: `local variable 'counter' should be pascal case and start with a 'l': 'lCounter'`,
-          type: "ForOfStatement",
-        },
-      ],
-    },
-    {
-      code: "function f(){for(let counter of [7,8,9]){var i = counter + i}}",
-      output:
-        "function f(){for(let lCounter of [7,8,9]){var i = lCounter + i}}",
-      errors: [
-        {
-          message: `local variable 'counter' should be pascal case and start with a 'l': 'lCounter'`,
-          type: "ForOfStatement",
-        },
-      ],
-    },
-  ],
-});
+ruleTesterTypeScriptParser.run(
+  "integration: local-variable-pattern - for-in statement - TypeScript parser",
+  rule,
+  LOCAL_VARIABLE_FOR_IN_STATEMENT_CASES
+);
 
-ruleTester.run("integration: local-variable-pattern - combo's", rule, {
+ruleTesterTypeScriptParser.run(
+  "integration: local-variable-pattern - for-of statement - default parser",
+  rule,
+  {
+    valid: ["for (let lCounter of [7,8,9]){var i = lCounter + i}"],
+    invalid: [
+      {
+        code: "for(let counter of [7,8,9]){}",
+        output: "for(let lCounter of [7,8,9]){}",
+        errors: [
+          {
+            message: `local variable 'counter' should be pascal case and start with a 'l': 'lCounter'`,
+            type: "ForOfStatement",
+          },
+        ],
+      },
+      {
+        code: "function f(){for(let counter of [7,8,9]){var i = counter + i}}",
+        output:
+          "function f(){for(let lCounter of [7,8,9]){var i = lCounter + i}}",
+        errors: [
+          {
+            message: `local variable 'counter' should be pascal case and start with a 'l': 'lCounter'`,
+            type: "ForOfStatement",
+          },
+        ],
+      },
+    ],
+  }
+);
+
+const LOCAL_VARIABLE_COMBO_CASES = {
   valid: [],
   // can't autofix overlapping ()
   invalid: [
@@ -421,9 +459,21 @@ ruleTester.run("integration: local-variable-pattern - combo's", rule, {
       ],
     },
   ],
-});
+};
 
-ruleTester.run("integration: local-variable-pattern - options", rule, {
+ruleTesterTypeScriptParser.run(
+  "integration: local-variable-pattern - combo's - TypeScript parser",
+  rule,
+  LOCAL_VARIABLE_COMBO_CASES
+);
+
+ruleTesterDefaultParser.run(
+  "integration: local-variable-pattern - combo's - default parser",
+  rule,
+  LOCAL_VARIABLE_COMBO_CASES
+);
+
+const LOCAL_VARIABLE_OPTIONS_CASES = {
   valid: [
     {
       code: "{ let x, y;}",
@@ -494,4 +544,16 @@ ruleTester.run("integration: local-variable-pattern - options", rule, {
       ],
     },
   ],
-});
+};
+
+ruleTesterTypeScriptParser.run(
+  "integration: local-variable-pattern - options - TypeScript parser",
+  rule,
+  LOCAL_VARIABLE_OPTIONS_CASES
+);
+
+ruleTesterDefaultParser.run(
+  "integration: local-variable-pattern - options - default parser",
+  rule,
+  LOCAL_VARIABLE_OPTIONS_CASES
+);

--- a/test/lib/rules/parameter-pattern-rule.spec.js
+++ b/test/lib/rules/parameter-pattern-rule.spec.js
@@ -1,12 +1,20 @@
 const rule = require("../../../lib/rules/parameter-pattern-rule");
 const RuleTester = require("eslint").RuleTester;
 
-const ruleTester = new RuleTester({
+const ruleTesterTypeScriptParser = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser"),
   parserOptions: {
     ecmaVersion: 2018,
   },
 });
-ruleTester.run("integration: parameter-pattern", rule, {
+
+const ruleTesterDefaultParser = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+  },
+});
+
+const PARAMETER_PATTERN_CASES = {
   valid: [
     "function doSomething(pLalala) { }",
     "function doSomething() { }",
@@ -185,9 +193,20 @@ ruleTester.run("integration: parameter-pattern", rule, {
       ],
     },
   ],
-});
+};
+ruleTesterTypeScriptParser.run(
+  "integration: parameter-pattern - TypeScript parser",
+  rule,
+  PARAMETER_PATTERN_CASES
+);
 
-ruleTester.run("integration: parameter-pattern unicode", rule, {
+ruleTesterDefaultParser.run(
+  "integration: parameter-pattern - default parser",
+  rule,
+  PARAMETER_PATTERN_CASES
+);
+
+const PARAMETER_PATTERN_UNICODE_CASES = {
   valid: [
     "function функция (pПараметр) { }",
     "const ф = (pПараметр) => { }",
@@ -270,4 +289,16 @@ ruleTester.run("integration: parameter-pattern unicode", rule, {
       ],
     },
   ],
-});
+};
+
+ruleTesterTypeScriptParser.run(
+  "integration: parameter-pattern unicode - TypeScript parser",
+  rule,
+  PARAMETER_PATTERN_UNICODE_CASES
+);
+
+ruleTesterDefaultParser.run(
+  "integration: parameter-pattern unicode - default parser",
+  rule,
+  PARAMETER_PATTERN_UNICODE_CASES
+);


### PR DESCRIPTION
## Description, Motivation and Context

In #20 we found out it's smart to also test rules with the typescript-eslint parser - this PR implements that for all integration tests on rules.

## How Has This Been Tested?

- [x] green ci
- [x] additional integration tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../blob/master/LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](.//blob/master/.github/CONTRIBUTING.md).
